### PR TITLE
Adapt for Conan Center Index

### DIFF
--- a/recipes/cppcodec/all/conanfile.py
+++ b/recipes/cppcodec/all/conanfile.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 from conans import ConanFile, tools
 
@@ -9,11 +6,10 @@ class CppcodecConan(ConanFile):
     name = "cppcodec"
     version = "0.2"
     license = "MIT"
-    author = "Alexander Zaitsev zamazan4ik@tut.by"
-    url = "https://github.com/ZaMaZaN4iK/conan-cppcodec"
+    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/tplgy/cppcodec"
     description = "Header-only C++11 library to encode/decode base64, base64url, base32, base32hex and hex (a.k.a. base16) as specified in RFC 4648, plus Crockford's base32"
-    topics = ("base64", "cpp11")
+    topics = ("base64", "cpp11", "codec", "base32")
     no_copy_sources = True
 
     _source_subfolder = "source_subfolder"
@@ -24,7 +20,7 @@ class CppcodecConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def package(self):
-        self.copy("*hpp", dst="include/cppcodec", src=os.path.join(self._source_subfolder, "cppcodec"))
+        self.copy("*hpp", dst=os.path.join("include", "cppcodec"), src=os.path.join(self._source_subfolder, "cppcodec"))
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)
 
     def package_info(self):

--- a/recipes/cppcodec/all/test_package/CMakeLists.txt
+++ b/recipes/cppcodec/all/test_package/CMakeLists.txt
@@ -6,9 +6,4 @@ conan_basic_setup()
 
 add_executable(example example.cpp)
 target_link_libraries(example ${CONAN_LIBS})
-
-# CTest is a testing tool that can be used to test your project.
-# enable_testing()
-# add_test(NAME example
-#          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-#          COMMAND example)
+set_property(TARGET example PROPERTY CXX_STANDARD 11)

--- a/recipes/cppcodec/all/test_package/conanfile.py
+++ b/recipes/cppcodec/all/test_package/conanfile.py
@@ -1,5 +1,4 @@
 import os
-
 from conans import ConanFile, CMake, tools
 
 
@@ -9,17 +8,10 @@ class CppcodecTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
-        # in "test_package"
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy("*.dll", dst="bin", src="bin")
-        self.copy("*.dylib*", dst="bin", src="lib")
-        self.copy('*.so*', dst='bin', src='lib')
-
     def test(self):
         if not tools.cross_building(self.settings):
-            os.chdir("bin")
-            self.run(".%sexample" % os.sep)
+            bin_path = os.path.join("bin", "example")
+            self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Consider the Conan hook [conan-center](https://github.com/conan-io/hooks/#conan-center), which can avoid many errors from CI jobs in Conan Center Index.

